### PR TITLE
Feat/monitoring/prometeus

### DIFF
--- a/booking-service/src/main/java/com/flight_booking/booking_service/infrastructure/config/SecurityConfig.java
+++ b/booking-service/src/main/java/com/flight_booking/booking_service/infrastructure/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
         .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 비활성화
         .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))// 세션을 Stateless로 설정
         .authorizeHttpRequests(auth -> {
+          auth.requestMatchers("/actuator/prometheus").permitAll();
           auth.anyRequest().authenticated(); // 모든 요청은 인증 필요
         })
         .addFilterBefore(authenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/config-server/src/main/resources/config-repo/booking-service.yml
+++ b/config-server/src/main/resources/config-repo/booking-service.yml
@@ -70,7 +70,3 @@ management:
     web:
       exposure:
         include: refresh, prometheus  # [Post] /actuator/refresh 엔드포인트 노출 (config server 변경사항 수동 갱신) + prometheus
-  prometheus:
-    metrics:
-      export:
-        enabled: true

--- a/config-server/src/main/resources/config-repo/flight-service.yml
+++ b/config-server/src/main/resources/config-repo/flight-service.yml
@@ -69,7 +69,3 @@ management:
     web:
       exposure:
         include: refresh, prometheus  # [Post] /actuator/refresh 엔드포인트 노출 (config server 변경사항 수동 갱신) + prometheus
-  prometheus:
-    metrics:
-      export:
-        enabled: true

--- a/config-server/src/main/resources/config-repo/gateway-service.yml
+++ b/config-server/src/main/resources/config-repo/gateway-service.yml
@@ -49,7 +49,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: refresh  # [Post] /actuator/refresh 엔드포인트 노출 (config server 변경사항 수동 갱신)
+        include: refresh, prometheus  # [Post] /actuator/refresh 엔드포인트 노출 (config server 변경사항 수동 갱신) + prometheus
 
 logging:
   level:

--- a/config-server/src/main/resources/config-repo/notification-service.yml
+++ b/config-server/src/main/resources/config-repo/notification-service.yml
@@ -46,8 +46,4 @@ management:
   endpoints:
     web:
       exposure:
-        include: refresh, prometheus  # [Post] /actuator/refresh 엔드포인트 노출 (config server 변경사항 수동 갱신)
-    prometheus:
-      metrics:
-        export:
-          enabled: true
+        include: refresh, prometheus  # [Post] /actuator/refresh 엔드포인트 노출 (config server 변경사항 수동 갱신) + prometheus

--- a/config-server/src/main/resources/config-repo/payment-service.yml
+++ b/config-server/src/main/resources/config-repo/payment-service.yml
@@ -70,7 +70,3 @@ management:
     web:
       exposure:
         include: refresh, prometheus  # [Post] /actuator/refresh 엔드포인트 노출 (config server 변경사항 수동 갱신) + prometheus
-  prometheus:
-    metrics:
-      export:
-        enabled: true

--- a/config-server/src/main/resources/config-repo/ticket-service.yml
+++ b/config-server/src/main/resources/config-repo/ticket-service.yml
@@ -69,7 +69,3 @@ management:
     web:
       exposure:
         include: refresh, prometheus  # [Post] /actuator/refresh 엔드포인트 노출 (config server 변경사항 수동 갱신) + prometheus
-  prometheus:
-    metrics:
-      export:
-        enabled: true

--- a/config-server/src/main/resources/config-repo/user-service.yml
+++ b/config-server/src/main/resources/config-repo/user-service.yml
@@ -69,8 +69,4 @@ management:
   endpoints:
     web:
       exposure:
-        include: refresh, prometheus  # [Post] /actuator/refresh 엔드포인트 노출 (config server 변경사항 수동 갱신)
-    prometheus:
-      metrics:
-        export:
-          enabled: true
+        include: refresh, prometheus  # [Post] /actuator/refresh 엔드포인트 노출 (config server 변경사항 수동 갱신) + prometheus

--- a/flight-service/src/main/java/com/flight_booking/flight_service/infrastructure/configuration/SecurityConfig.java
+++ b/flight-service/src/main/java/com/flight_booking/flight_service/infrastructure/configuration/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
         .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 비활성화
         .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))// 세션을 Stateless로 설정
         .authorizeHttpRequests(auth -> {
+          auth.requestMatchers("/actuator/prometheus").permitAll();
           auth.anyRequest().authenticated(); // 모든 요청은 인증 필요
         })
         .addFilterBefore(authenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -20,6 +20,11 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.session:spring-session-data-redis'
+
+	// Redis Session Clustering
+	implementation 'org.springframework.session:spring-session-data-redis'
+
+	// Jedis
 	implementation 'redis.clients:jedis:5.2.0'
 
 	// Security & JWT
@@ -29,6 +34,8 @@ dependencies {
 
 	// Feign Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+	// Eureka Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	// config client
@@ -37,6 +44,7 @@ dependencies {
 	// Tracing & Metrics
 	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+	implementation 'io.github.openfeign:feign-micrometer'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
 	// Resilience4j

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
+	// config client
+	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+
 	// Tracing & Metrics
 	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'

--- a/notification-service/src/main/java/com/flight_booking/notification_service/infrastructure/config/SecurityConfig.java
+++ b/notification-service/src/main/java/com/flight_booking/notification_service/infrastructure/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
         .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 비활성화
         .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))// 세션을 Stateless로 설정
         .authorizeHttpRequests(auth -> {
+          auth.requestMatchers("/actuator/prometheus").permitAll();
           auth.anyRequest().authenticated(); // 모든 요청은 인증 필요
         })
         .addFilterBefore(authenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8160  # Temporary port, will be overwritten by Config server settings later.
+  port: 0  # Temporary port, will be overwritten by Config server settings later.
 
 spring:
   application:
@@ -9,7 +9,7 @@ spring:
   cloud:
     config:
       discovery:
-        enabled: true  # Discover Config Server through Eureka
+        enabled: true
         service-id: config-server
 
 eureka:

--- a/payment-service/src/main/java/com/flight_booking/payment_service/infrastructure/configuration/SecurityConfig.java
+++ b/payment-service/src/main/java/com/flight_booking/payment_service/infrastructure/configuration/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
         .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 비활성화
         .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))// 세션을 Stateless로 설정
         .authorizeHttpRequests(auth -> {
+          auth.requestMatchers("/actuator/prometheus").permitAll();
           auth.anyRequest().authenticated(); // 모든 요청은 인증 필요
         })
         .addFilterBefore(authenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,35 +1,80 @@
-#global:
-#  scrape_interval: 15s
-#
+global:
+  scrape_interval: 15s
+
+
+# local 로 실행 할 때의 설정
+scrape_configs:
+  - job_name: 'gateway'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+
+  - job_name: 'user-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8100']
+
+  - job_name: 'booking-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8120']
+
+  - job_name: 'payment-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8130']
+
+  - job_name: 'ticket-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8140']
+
+  - job_name: 'flight-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8150']
+
+  - job_name: 'notification-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8160']
+
+
+
+# Docker 로 실행 할 때의 설정
+
 #scrape_configs:
 #  - job_name: 'gateway'
+#    metrics_path: '/actuator/prometheus'
 #    static_configs:
 #      - targets: ['gateway-server:8080']
 #
 #  - job_name: 'user-service'
+#    metrics_path: '/actuator/prometheus'
 #    static_configs:
 #      - targets: ['user-service:8100']
 #
-#  - job_name: 'auth-service'
-#    static_configs:
-#      - targets: ['auth-service:8110']
-#
 #  - job_name: 'booking-service'
+#    metrics_path: '/actuator/prometheus'
 #    static_configs:
 #      - targets: ['booking-service:8120']
 #
 #  - job_name: 'payment-service'
+#    metrics_path: '/actuator/prometheus'
 #    static_configs:
 #      - targets: ['payment-service:8130']
 #
 #  - job_name: 'ticket-service'
+#    metrics_path: '/actuator/prometheus'
 #    static_configs:
 #      - targets: ['ticket-service:8140']
 #
 #  - job_name: 'flight-service'
+#    metrics_path: '/actuator/prometheus'
 #    static_configs:
 #      - targets: ['flight-service:8150']
 #
 #  - job_name: 'notification-service'
+#    metrics_path: '/actuator/prometheus'
 #    static_configs:
 #      - targets: ['notification-service:8160']

--- a/ticket-service/src/main/java/com/flight_booking/ticket_service/infrastructure/configuration/SecurityConfig.java
+++ b/ticket-service/src/main/java/com/flight_booking/ticket_service/infrastructure/configuration/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
         .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 비활성화
         .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))// 세션을 Stateless로 설정
         .authorizeHttpRequests(auth -> {
+          auth.requestMatchers("/actuator/prometheus").permitAll();
           auth.anyRequest().authenticated(); // 모든 요청은 인증 필요
         })
         .addFilterBefore(authenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/user-service/src/main/java/com/flight_booking/user_service/infrastructure/configuration/SecurityConfig.java
+++ b/user-service/src/main/java/com/flight_booking/user_service/infrastructure/configuration/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
         .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 비활성화
         .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))// 세션을 Stateless로 설정
         .authorizeHttpRequests(auth -> {
+          auth.requestMatchers("/actuator/prometheus").permitAll();
           auth.requestMatchers(permitPaths).permitAll(); // 허용
           auth.anyRequest().authenticated(); // 모든 요청은 인증 필요
         })


### PR DESCRIPTION
## #️⃣ Issue Number

- #58 

## 📝 요약(Summary)

- 각 서비스 prometheus endpoint 설정 (config-server)
- Spring security permit path 설정
- prometheus.yml 작성

## 💬 공유사항 to 리뷰어

- prometheus.yml에 `metrics_path: '/actuator/prometheus'` 추가하여 prometheus가 엔드포인트에 접근하지 못하는 에러 해결

- prometheus 실행시 명령어: 

docker run -d --name=prometheus -p 9090:9090 -v _**"prometheus.yml의 경로"**_/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus

- 예시 : 

`docker run -d --name=prometheus -p 9090:9090 -v C:/code/spartaPlus/flight-booking/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus`

- host.docker.internal :
컨테이너 내에서 실행 중인 애플리케이션이 호스트 시스템(즉, Docker를 실행하는 컴퓨터)에 접근할 수 있도록 함.

### @HanBeom98  **각 서버를 도커컴포즈로 실행시 prometheus.yml의 주석 부분으로 교체 필요 할 것 같습니다.**

<br>

## 📷 스크린샷

- prometheus 상태
![image](https://github.com/user-attachments/assets/875f98dc-8264-4fd3-b0f2-ca6d219b6499)

- grafana 대시보드
instance를 변경하여 다른 서버의 대시보드 확인 가능
![image](https://github.com/user-attachments/assets/f88d3312-6ce7-48a6-850e-84deae8b2cfa)

- docker-compose.yml 예시
![image](https://github.com/user-attachments/assets/1bfedf2d-3ccd-48d2-b91d-cbf3a97696b6)

