### PR TITLE
fix: ticket 이 1개만 생성되는 오류 수정

### DIFF
--- a/ticket-service/src/main/java/com/flight_booking/ticket_service/application/service/TicketService.java
+++ b/ticket-service/src/main/java/com/flight_booking/ticket_service/application/service/TicketService.java
@@ -33,11 +33,6 @@ public class TicketService {
   @Transactional
   public TicketResponseDto createTicket(TicketRequestDto ticketRequestDto) {
 
-    // 예약에 해당하는 항공권이 이미 있는지 확인
-    if (ticketRepository.existsByBookingId(ticketRequestDto.bookingId())) {
-      throw new RuntimeException("해당 예약에 대한 항공권이 이미 존재합니다.");
-    }
-
     Ticket ticket = Ticket.builder()
         .bookingId(ticketRequestDto.bookingId())
         .passengerId(ticketRequestDto.passengerId())


### PR DESCRIPTION
## #️⃣ Issue Number

- #61 

## 📝 요약(Summary)

- 티켓 생성 시 
   for문을 통하여 booking에서 전송된 탑승객 목록을 순회하며 ticket create topic을 전송하는데,
   
  > // 예약에 해당하는 항공권이 이미 있는지 확인
  if (ticketRepository.existsByBookingId(ticketRequestDto.bookingId())) {
        throw new RuntimeException("해당 예약에 대한 항공권이 이미 존재합니다.");
  }
  
  해당 조건문으로 인해 한개만 생성되는 버그 발생, 이를 제거함

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📷 스크린샷

<!--- 선택사항 -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
