### PR TITLE
fix: Common Main 클래스 삭제

### DIFF
--- a/common/src/main/java/com/flight_booking/common/Main.java
+++ b/common/src/main/java/com/flight_booking/common/Main.java
@@ -1,8 +1,0 @@
-package com.flight_booking.common;
-
-public class Main {
-
-  public static void main(String[] args) {
-    System.out.println("Hello world!");
-  }
-}


### PR DESCRIPTION
## #️⃣ Issue Number

- #65 

## 📝 요약(Summary)

- Common 모듈의 Main.java 삭제

## 💬 공유사항 to 리뷰어

> Main.java가 공통 모듈에 남아있다면, Gradle은 해당 파일을 실행하려고 시도할 수 있음. 
이를 방지하기 위해, Main.java를 공통 모듈에서 제거

구현 중 미쳐 확인하지 못했던 부분이라 수정하였습니다.