### PR TITLE
fix: Feign 호출시 인증 오류 해결

### DIFF
--- a/common/src/main/java/com/flight_booking/common/infrastructure/security/AuthenticationFilter.java
+++ b/common/src/main/java/com/flight_booking/common/infrastructure/security/AuthenticationFilter.java
@@ -1,11 +1,9 @@
 package com.flight_booking.common.infrastructure.security;
 
-import com.flight_booking.common.domain.model.UserRoleEnum;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.NotNull;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -23,18 +21,12 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 
     // 헤더에서 사용자 정보 추출
     String email = request.getHeader("X-USER-EMAIL");
-    String header = request.getHeader("X-USER-ROLE");
+    String role = request.getHeader("X-USER-ROLE");
 
-    log.info("header: {}, {}", email, header);
+    log.info("header: email: {}, role: {}", email, role);
 
-    if (email != null && header != null) {
+    if (email != null && role != null) {
       try {
-        // "ROLE_" 접두어 제거
-        String roleName = header.replace("ROLE_", "");
-
-        // UserRoleEnum에 맞게 변환
-        UserRoleEnum role = UserRoleEnum.valueOf(roleName);
-
         // 이메일로 사용자 정보 로드
         UserDetails userDetails = new CustomUserDetails(email, role);
 

--- a/common/src/main/java/com/flight_booking/common/infrastructure/security/CustomUserDetails.java
+++ b/common/src/main/java/com/flight_booking/common/infrastructure/security/CustomUserDetails.java
@@ -1,6 +1,5 @@
 package com.flight_booking.common.infrastructure.security;
 
-import com.flight_booking.common.domain.model.UserRoleEnum;
 import java.util.Collection;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -8,12 +7,12 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 public record CustomUserDetails(
     String email,
-    UserRoleEnum role
+    String role
 ) implements UserDetails {
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    return AuthorityUtils.createAuthorityList(this.role.getAuthority());
+    return AuthorityUtils.createAuthorityList(this.role);
   }
 
   @Override


### PR DESCRIPTION
## #️⃣ Issue Number

- #67 

## 📝 요약(Summary)

> FeignClient 호출시 헤더값을 넣어줬음에도 불구하고 인증 오류

- 원인: CustomUserDetails의 Role이 Enum으로 되어 있던 문제
- 해결: String으로 교체 후 CustomUserDetails의 getAuthorities에 해당 값 입력.

## 💬 공유사항 to 리뷰어

@ykybkoft 
- Spring Security에서는 역할 이름에 "ROLE_" 접두사를 붙여야 역할을 제대로 인식할 수 있습니다.

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/dbcfc5bc-3788-4791-9e94-5dcb0f184938)

![image](https://github.com/user-attachments/assets/f364f2ec-0a32-4630-8317-b73e854c5675)


