### PR TITLE
Feat: PaymentRetryWorker 구현

### DIFF
--- a/common/src/main/java/com/flight_booking/common/application/dto/PaymentRetryRequestDto.java
+++ b/common/src/main/java/com/flight_booking/common/application/dto/PaymentRetryRequestDto.java
@@ -1,0 +1,26 @@
+package com.flight_booking.common.application.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.UUID;
+
+public record PaymentRetryRequestDto(
+    @NotNull(message = "User Email cannot be null") String email,
+    @NotNull(message = "Booking ID cannot be null") UUID bookingId,
+    @NotNull(message = "Fare cannot be null") @Positive(message = "Fare must be positive") Long fare,
+    int retryCount
+) {
+
+  public static PaymentRetryRequestDto from(
+      PaymentRetryRequestDto paymentRetryRequestDto, int retryCount) {
+
+    return new PaymentRetryRequestDto(
+        paymentRetryRequestDto.email,
+        paymentRetryRequestDto.bookingId,
+        paymentRetryRequestDto.fare,
+        retryCount
+    );
+  }
+
+}
+

--- a/config-server/src/main/resources/config-repo/payment-service.yml
+++ b/config-server/src/main/resources/config-repo/payment-service.yml
@@ -70,3 +70,7 @@ management:
     web:
       exposure:
         include: refresh, prometheus  # [Post] /actuator/refresh 엔드포인트 노출 (config server 변경사항 수동 갱신) + prometheus
+
+retry-payment:
+  scheduler:
+    thread-pool: 10

--- a/payment-service/src/main/java/com/flight_booking/payment_service/PaymentServiceApplication.java
+++ b/payment-service/src/main/java/com/flight_booking/payment_service/PaymentServiceApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 @ComponentScan(basePackages = {"com.flight_booking.payment_service", "com.flight_booking.common"})
 public class PaymentServiceApplication {
 

--- a/payment-service/src/main/java/com/flight_booking/payment_service/infrastructure/messaging/PaymentRetryWorker.java
+++ b/payment-service/src/main/java/com/flight_booking/payment_service/infrastructure/messaging/PaymentRetryWorker.java
@@ -1,0 +1,86 @@
+package com.flight_booking.payment_service.infrastructure.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flight_booking.common.application.dto.PaymentRetryRequestDto;
+import com.flight_booking.common.infrastructure.util.StackTraceUtils;
+import com.flight_booking.common.presentation.global.ApiResponse;
+import com.flight_booking.payment_service.application.service.PaymentService;
+import com.flight_booking.payment_service.infrastructure.scheduling.PaymentScheduler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentRetryWorker {
+
+  private final PaymentKafkaSender paymentKafkaSender;
+  private final PaymentScheduler paymentScheduler;
+  private final PaymentService paymentService;
+
+  private final int MAX_RETRY_COUNT = 5;
+  private final int[] delays = {3, 5, 7, 9, 10}; // minutes
+
+  @KafkaListener(groupId = "payment-retry-group", topics = "payment-retry-topic")
+  public void processRetry(@Payload ApiResponse<PaymentRetryRequestDto> message) {
+
+    ObjectMapper mapper = new ObjectMapper();
+    PaymentRetryRequestDto requestDto
+        = mapper.convertValue(message.getData(), PaymentRetryRequestDto.class);
+
+    int retryCount = requestDto.retryCount();
+
+    if (retryCount == 0) {
+      long delay = (long) delays[0] * 1000 * 60;
+      retryCount++;
+
+      schedulePaymentRetry(requestDto, retryCount, delay);
+
+      return;
+    }
+
+    if (retryCount >= MAX_RETRY_COUNT) {
+      // TODO 예매 취소 로직
+      // TODO 유저에게 알림 발송
+      paymentKafkaSender.sendMessage(
+          "payment-dlq-topic", requestDto.email(), requestDto,
+          StackTraceUtils.getCurrentMethodName(), StackTraceUtils.getCurrentClassName());
+      return;
+    }
+
+    try {
+      // 결제 재시도
+      boolean success = retryPayment(requestDto);
+      if (success) {
+        log.info("Payment Retry Success, BookingId: " + requestDto.bookingId());
+        // TODO 유저에게 알림 발솔
+      } else {
+        throw new RuntimeException("Payment failed");
+      }
+    } catch (RuntimeException e) {
+      log.error("Payment Retry failed, BookingId: " + requestDto.bookingId()
+          + " , Retry Count: " + retryCount);
+      long delay = (long) delays[retryCount] * 1000 * 60;
+      retryCount++;
+      schedulePaymentRetry(requestDto, retryCount, delay);
+    }
+
+  }
+
+
+  private void schedulePaymentRetry(PaymentRetryRequestDto requestDto, int retryCount, long delay) {
+    PaymentRetryRequestDto updatedRequestDto
+        = PaymentRetryRequestDto.from(requestDto, retryCount);
+    paymentScheduler.scheduleRetryWithDelay(delay, updatedRequestDto);
+  }
+
+  private boolean retryPayment(PaymentRetryRequestDto requestDto) {
+    // 재결제 메서드 호출 TODO
+//    boolean success = paymentService.retryPayment(requestDto);
+
+    return Math.random() > 0.5;
+  }
+
+
+}

--- a/payment-service/src/main/java/com/flight_booking/payment_service/infrastructure/scheduling/PaymentScheduler.java
+++ b/payment-service/src/main/java/com/flight_booking/payment_service/infrastructure/scheduling/PaymentScheduler.java
@@ -1,0 +1,51 @@
+package com.flight_booking.payment_service.infrastructure.scheduling;
+
+import com.flight_booking.common.application.dto.PaymentRetryRequestDto;
+import com.flight_booking.common.infrastructure.util.StackTraceUtils;
+import com.flight_booking.payment_service.infrastructure.messaging.PaymentKafkaSender;
+import jakarta.annotation.PostConstruct;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class PaymentScheduler {
+
+  @Value("${retry-payment.scheduler.thread-pool}")
+  private int threadPool;
+
+  private ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(threadPool);
+  private final PaymentKafkaSender paymentKafkaSender;
+
+  @PostConstruct
+  public void init() {
+    this.scheduler = Executors.newScheduledThreadPool(threadPool);
+  }
+
+  @RefreshScope
+  @PostConstruct // @RefreshScope 와 결합하면 refresh 엔드포인트 호출시 다시 호출되어 해당 빈의 필드 값이 다시 주입됨.
+  public void refreshScheduler() {
+    this.scheduler.shutdown();  // 기존 스케줄러 종료
+    this.scheduler = Executors.newScheduledThreadPool(threadPool);  // 새로운 스케줄러 생성
+    log.info("Scheduler thread pool has been refreshed with new size: " + threadPool);
+  }
+
+  public void scheduleRetryWithDelay(long delay, PaymentRetryRequestDto requestDto) {
+    log.info("Payment retry is scheduled, BookingId: " + requestDto.bookingId());
+
+    scheduler.schedule(() -> {
+      paymentKafkaSender.sendMessage(
+          "payment-retry-topic", requestDto.bookingId().toString(), requestDto,
+          StackTraceUtils.getCurrentMethodName(), StackTraceUtils.getCurrentClassName()
+      );
+    }, delay, TimeUnit.MILLISECONDS);
+  }
+
+}


### PR DESCRIPTION
## #️⃣ Issue Number

- #72 
- #83 

## 📝 요약(Summary)

- 결제 실패시 예약이 취소되지 않고 일정 시간 동안 텀을 두며 재시도
- 일정 시간 이후에는 예매 취소

## 💬 공유사항 to 리뷰어

- Retry Queue 구현
- DLQ(Dead Letter Queue) 사용
- Exponential Backoff (지수 백오프)가 아닌 배열로 구현
  - 시간이 짧고 횟수도 적어져 배열을 사용했습니다. 더 좋은 방법이 있다면 공유 부탁드립니다.

- Retry Queue의 Delay를 scheduler 로 구현
  - ScheduledExecutorService 사용
  - @RefreshScope 활용하여 Scheduler의 스레드풀을 동적으로 할당

- API 호출 등 특정 부분 미구현 


## 📷 스크린샷
![image](https://github.com/user-attachments/assets/a3b3f4b2-6595-4314-a493-be547a76ef09)

