### PR TITLE
fix: Kafka URL 설정 주입 처리

### DIFF
--- a/booking-service/src/main/java/com/flight_booking/booking_service/infrastructure/config/kafka/ConsumerApplicationKafkaConfig.java
+++ b/booking-service/src/main/java/com/flight_booking/booking_service/infrastructure/config/kafka/ConsumerApplicationKafkaConfig.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -19,6 +20,9 @@ import org.springframework.kafka.support.serializer.JsonDeserializer;
 @Configuration // Spring 설정 클래스로 선언하는 어노테이션입니다.
 public class ConsumerApplicationKafkaConfig {
 
+  @Value("${service.kafka.url}")
+  private String url;
+
   // Kafka 컨슈머 팩토리를 생성하는 빈을 정의합니다.
   // ConsumerFactory는 Kafka 컨슈머 인스턴스를 생성하는 데 사용됩니다.
   // 각 컨슈머는 이 팩토리를 통해 생성된 설정을 기반으로 작동합니다.
@@ -27,7 +31,7 @@ public class ConsumerApplicationKafkaConfig {
     // 컨슈머 팩토리 설정을 위한 맵을 생성
     Map<String, Object> configProps = new HashMap<>();
     // Kafka 브로커의 주소를 설정
-    configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
     // 메시지 키의 디시리얼라이저 클래스를 설정
     configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 

--- a/booking-service/src/main/java/com/flight_booking/booking_service/infrastructure/config/kafka/ProducerApplicationKafkaConfig.java
+++ b/booking-service/src/main/java/com/flight_booking/booking_service/infrastructure/config/kafka/ProducerApplicationKafkaConfig.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
@@ -14,10 +15,14 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 
 @Configuration
 public class ProducerApplicationKafkaConfig {
+
+  @Value("${service.kafka.url}")
+  private String url;
+
   @Bean
   public ProducerFactory<String, ApiResponse<?>> apiResponseProducerFactory() {
     Map<String, Object> configProps = new HashMap<>();
-    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
     configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
     return new DefaultKafkaProducerFactory<>(configProps);

--- a/config-server/src/main/resources/config-repo/booking-service.yml
+++ b/config-server/src/main/resources/config-repo/booking-service.yml
@@ -2,9 +2,8 @@ server:
   port: 8120
 
 service:
-  jwt:
-    access-expiration: 86400000  # 24시간
-    secret-key: ${SECRET_KEY}
+  kafka:
+    url: localhost:9092
 
 
 spring:

--- a/config-server/src/main/resources/config-repo/flight-service.yml
+++ b/config-server/src/main/resources/config-repo/flight-service.yml
@@ -2,9 +2,8 @@ server:
   port: 8150
 
 service:
-  jwt:
-    access-expiration: 86400000  # 24시간
-    secret-key: ${SECRET_KEY}
+  kafka:
+    url: localhost:9092
 
 
 spring:
@@ -69,3 +68,6 @@ management:
     web:
       exposure:
         include: refresh, prometheus  # [Post] /actuator/refresh 엔드포인트 노출 (config server 변경사항 수동 갱신) + prometheus
+
+kafka:
+  url: ${KAFKA_URL}

--- a/config-server/src/main/resources/config-repo/notification-service.yml
+++ b/config-server/src/main/resources/config-repo/notification-service.yml
@@ -1,6 +1,10 @@
 server:
   port: 8160
 
+service:
+  kafka:
+    url: localhost:9092
+
 spring:
   datasource:
     driver-class-name: org.postgresql.Driver

--- a/config-server/src/main/resources/config-repo/payment-service.yml
+++ b/config-server/src/main/resources/config-repo/payment-service.yml
@@ -2,9 +2,8 @@ server:
   port: 8130
 
 service:
-  jwt:
-    access-expiration: 86400000  # 24시간
-    secret-key: ${SECRET_KEY}
+  kafka:
+    url: localhost:9092
 
 
 spring:

--- a/config-server/src/main/resources/config-repo/ticket-service.yml
+++ b/config-server/src/main/resources/config-repo/ticket-service.yml
@@ -2,9 +2,8 @@ server:
   port: 8140
 
 service:
-  jwt:
-    access-expiration: 86400000  # 24시간
-    secret-key: ${SECRET_KEY}
+  kafka:
+    url: localhost:9092
 
 
 spring:

--- a/config-server/src/main/resources/config-repo/user-service.yml
+++ b/config-server/src/main/resources/config-repo/user-service.yml
@@ -5,6 +5,8 @@ service:
   jwt:
     access-expiration: 86400000  # 24시간
     secret-key: ${SECRET_KEY}
+  kafka:
+    url: localhost:9092
 
 
 spring:

--- a/flight-service/src/main/java/com/flight_booking/flight_service/infrastructure/configuration/kafka/ConsumerApplicationKafkaConfig.java
+++ b/flight-service/src/main/java/com/flight_booking/flight_service/infrastructure/configuration/kafka/ConsumerApplicationKafkaConfig.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -22,12 +23,15 @@ public class ConsumerApplicationKafkaConfig {
   // Kafka 컨슈머 팩토리를 생성하는 빈을 정의합니다.
   // ConsumerFactory는 Kafka 컨슈머 인스턴스를 생성하는 데 사용됩니다.
   // 각 컨슈머는 이 팩토리를 통해 생성된 설정을 기반으로 작동합니다.
+  @Value("${kafka.url}")
+  String url;
+
   @Bean
   public ConsumerFactory<String, ApiResponse<?>> consumerFactory() {
     // 컨슈머 팩토리 설정을 위한 맵을 생성
     Map<String, Object> configProps = new HashMap<>();
     // Kafka 브로커의 주소를 설정
-    configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
     // 메시지 키의 디시리얼라이저 클래스를 설정
     configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 

--- a/flight-service/src/main/java/com/flight_booking/flight_service/infrastructure/configuration/kafka/ProducerApplicationKafkaConfig.java
+++ b/flight-service/src/main/java/com/flight_booking/flight_service/infrastructure/configuration/kafka/ProducerApplicationKafkaConfig.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
@@ -15,10 +16,13 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 @Configuration
 public class ProducerApplicationKafkaConfig {
 
+  @Value("${service.kafka.url}")
+  private String url;
+
   @Bean
   public ProducerFactory<String, ApiResponse<?>> apiResponseProducerFactory() {
     Map<String, Object> configProps = new HashMap<>();
-    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
     configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
     return new DefaultKafkaProducerFactory<>(configProps);

--- a/notification-service/src/main/java/com/flight_booking/notification_service/global/configuration/ConsumerApplicationKafkaConfig.java
+++ b/notification-service/src/main/java/com/flight_booking/notification_service/global/configuration/ConsumerApplicationKafkaConfig.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -19,6 +20,9 @@ import org.springframework.kafka.support.serializer.JsonDeserializer;
 @Configuration // Spring 설정 클래스로 선언하는 어노테이션입니다.
 public class ConsumerApplicationKafkaConfig {
 
+  @Value("${service.kafka.url}")
+  private String url;
+
   // Kafka 컨슈머 팩토리를 생성하는 빈을 정의합니다.
   // ConsumerFactory는 Kafka 컨슈머 인스턴스를 생성하는 데 사용됩니다.
   // 각 컨슈머는 이 팩토리를 통해 생성된 설정을 기반으로 작동합니다.
@@ -27,7 +31,7 @@ public class ConsumerApplicationKafkaConfig {
     // 컨슈머 팩토리 설정을 위한 맵을 생성
     Map<String, Object> configProps = new HashMap<>();
     // Kafka 브로커의 주소를 설정
-    configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
     // 메시지 키의 디시리얼라이저 클래스를 설정
     configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 

--- a/payment-service/src/main/java/com/flight_booking/payment_service/infrastructure/configuration/kafka/ConsumerApplicationKafkaConfig.java
+++ b/payment-service/src/main/java/com/flight_booking/payment_service/infrastructure/configuration/kafka/ConsumerApplicationKafkaConfig.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -19,6 +20,9 @@ import com.flight_booking.common.presentation.global.ApiResponse;
 @Configuration // Spring 설정 클래스로 선언하는 어노테이션입니다.
 public class ConsumerApplicationKafkaConfig {
 
+  @Value("${service.kafka.url}")
+  private String url;
+
   // Kafka 컨슈머 팩토리를 생성하는 빈을 정의합니다.
   // ConsumerFactory는 Kafka 컨슈머 인스턴스를 생성하는 데 사용됩니다.
   // 각 컨슈머는 이 팩토리를 통해 생성된 설정을 기반으로 작동합니다.
@@ -27,7 +31,7 @@ public class ConsumerApplicationKafkaConfig {
     // 컨슈머 팩토리 설정을 위한 맵을 생성
     Map<String, Object> configProps = new HashMap<>();
     // Kafka 브로커의 주소를 설정
-    configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
     // 메시지 키의 디시리얼라이저 클래스를 설정
     configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 

--- a/payment-service/src/main/java/com/flight_booking/payment_service/infrastructure/configuration/kafka/ProducerApplicationKafkaConfig.java
+++ b/payment-service/src/main/java/com/flight_booking/payment_service/infrastructure/configuration/kafka/ProducerApplicationKafkaConfig.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
@@ -14,10 +15,14 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 
 @Configuration
 public class ProducerApplicationKafkaConfig {
+
+  @Value("${service.kafka.url}")
+  private String url;
+
   @Bean
   public ProducerFactory<String, ApiResponse<?>> apiResponseProducerFactory() {
     Map<String, Object> configProps = new HashMap<>();
-    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
     configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
     return new DefaultKafkaProducerFactory<>(configProps);

--- a/ticket-service/src/main/java/com/flight_booking/ticket_service/infrastructure/configuration/kafka/ConsumerApplicationKafkaConfig.java
+++ b/ticket-service/src/main/java/com/flight_booking/ticket_service/infrastructure/configuration/kafka/ConsumerApplicationKafkaConfig.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -19,6 +20,9 @@ import org.springframework.kafka.support.serializer.JsonDeserializer;
 @Configuration // Spring 설정 클래스로 선언하는 어노테이션입니다.
 public class ConsumerApplicationKafkaConfig {
 
+  @Value("${service.kafka.url}")
+  private String url;
+
   // Kafka 컨슈머 팩토리를 생성하는 빈을 정의합니다.
   // ConsumerFactory는 Kafka 컨슈머 인스턴스를 생성하는 데 사용됩니다.
   // 각 컨슈머는 이 팩토리를 통해 생성된 설정을 기반으로 작동합니다.
@@ -27,7 +31,7 @@ public class ConsumerApplicationKafkaConfig {
     // 컨슈머 팩토리 설정을 위한 맵을 생성
     Map<String, Object> configProps = new HashMap<>();
     // Kafka 브로커의 주소를 설정
-    configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
     // 메시지 키의 디시리얼라이저 클래스를 설정
     configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 

--- a/ticket-service/src/main/java/com/flight_booking/ticket_service/infrastructure/configuration/kafka/ProducerApplicationKafkaConfig.java
+++ b/ticket-service/src/main/java/com/flight_booking/ticket_service/infrastructure/configuration/kafka/ProducerApplicationKafkaConfig.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
@@ -15,10 +16,13 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 @Configuration
 public class ProducerApplicationKafkaConfig {
 
+  @Value("${service.kafka.url}")
+  private String url;
+
   @Bean
   public ProducerFactory<String, ApiResponse<?>> apiResponseProducerFactory() {
     Map<String, Object> configProps = new HashMap<>();
-    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
     configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
     return new DefaultKafkaProducerFactory<>(configProps);

--- a/user-service/src/main/java/com/flight_booking/user_service/infrastructure/configuration/kafka/ConsumerApplicationKafkaConfig.java
+++ b/user-service/src/main/java/com/flight_booking/user_service/infrastructure/configuration/kafka/ConsumerApplicationKafkaConfig.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -19,6 +20,9 @@ import org.springframework.kafka.support.serializer.JsonDeserializer;
 @Configuration // Spring 설정 클래스로 선언하는 어노테이션입니다.
 public class ConsumerApplicationKafkaConfig {
 
+  @Value("${service.kafka.url}")
+  private String url;
+
   // Kafka 컨슈머 팩토리를 생성하는 빈을 정의합니다.
   // ConsumerFactory는 Kafka 컨슈머 인스턴스를 생성하는 데 사용됩니다.
   // 각 컨슈머는 이 팩토리를 통해 생성된 설정을 기반으로 작동합니다.
@@ -27,7 +31,7 @@ public class ConsumerApplicationKafkaConfig {
     // 컨슈머 팩토리 설정을 위한 맵을 생성
     Map<String, Object> configProps = new HashMap<>();
     // Kafka 브로커의 주소를 설정
-    configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
     // 메시지 키의 디시리얼라이저 클래스를 설정
     configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 

--- a/user-service/src/main/java/com/flight_booking/user_service/infrastructure/configuration/kafka/ProducerApplicationKafkaConfig.java
+++ b/user-service/src/main/java/com/flight_booking/user_service/infrastructure/configuration/kafka/ProducerApplicationKafkaConfig.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
@@ -15,10 +16,14 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 
 @Configuration
 public class ProducerApplicationKafkaConfig {
+
+  @Value("${service.kafka.url}")
+  private String url;
+
   @Bean
   public ProducerFactory<String, ApiResponse<?>> apiResponseProducerFactory() {
     Map<String, Object> configProps = new HashMap<>();
-    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
     configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
     return new DefaultKafkaProducerFactory<>(configProps);
@@ -33,7 +38,7 @@ public class ProducerApplicationKafkaConfig {
   @Bean
   public ProducerFactory<String, NotificationRequestDto> notificationProducerFactory() {
     Map<String, Object> configProps = new HashMap<>();
-    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
     configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
     return new DefaultKafkaProducerFactory<>(configProps);


### PR DESCRIPTION
## 📝 요약(Summary)

- kafka 연동에 필요한 url을 각 서비스의 설정파일에서 주입받습니다.

## 💬 공유사항 to 리뷰어

- 로컬에서 실행시 추가해주실 것은 없습니다.

- @HanBeom98 배포 환경(Docker)에서는 `kafka:9092` 사용하기 때문에
배포시 사용되는 config-repo 설정파일의 `localhost:9092`을 `kafka:9092`로 변경해주시면 됩니다.

## 📷 스크린샷

![image](https://github.com/user-attachments/assets/4736f386-c2a6-478e-8388-f97418610614)

![image](https://github.com/user-attachments/assets/90a9b7cf-6045-455f-8a05-76d311641f5e)
